### PR TITLE
Testing out with Cornell movie_lines.txt

### DIFF
--- a/irc_conversations.lua
+++ b/irc_conversations.lua
@@ -15,7 +15,8 @@ local function parsedLines(file, fields)
       return
     end
 
-    local values = stringx.split(line, " -:-~-:- ")
+    -- local values = stringx.split(line, " -:-~-:- ")
+    local values = stringx.split( line, " +++$+++ ")
     local t = {}
 
     for i,field in ipairs(fields) do
@@ -37,7 +38,7 @@ local function progress(c)
 	end
 end
 
-local DATASET_FIELDS = {"conv_id","character","text"}
+local DATASET_FIELDS = {"conv_id", "character_id", "movie_id", "character","text"}
 
 function IrcDialogs:load()
 	local lines = {}
@@ -48,7 +49,7 @@ function IrcDialogs:load()
 
 	print("Parsing IRC conversation...")
 
-	for conv in parsedLines(self.dir .. "/conversation.log", DATASET_FIELDS) do
+	for conv in parsedLines(self.dir .. "/cornell_movie_dialogs/movie_lines.txt", DATASET_FIELDS) do
 		if prevConvID ~= conv.conv_id then
 			if #conversation > 0 then
 				table.insert(conversations, conversation)


### PR DESCRIPTION
I'm attempting to get this to function. I tried changing it to use the `movie_lines.txt` from the references Cornell datasource.

I've also tried as is with a fake generated `conversation.log` but in both cases I end up with this error.

```
neuralconvo (master) $ th train.lua --dataset 50000
-- Loading dataset  
data/vocab.t7 not found 
Parsing IRC conversation... 
 [============================= 542008/542008 =====================>] Tot: 3s671ms | Step: 0ms      
-- Pre-processing data  
 [============================= 50000/50000 =======================>] Tot: 969ms | Step: 0ms        
-- Shuffling    
/Users/beaucollins/code/torch/install/bin/luajit: bad argument #1 to '?' (must be strictly positive at /Users/beaucollins/code/torch/pkg/torch/lib/TH/generic/THTensorMath.c:1418)
stack traceback:
    [C]: at 0x018cb600
    [C]: in function 'randperm'
    ./dataset.lua:95: in function 'visit'
    ./dataset.lua:55: in function 'load'
    ./dataset.lua:37: in function '__init'
    ...ucollins/code/torch/install/share/lua/5.1/torch/init.lua:91: in function <...ucollins/code/torch/install/share/lua/5.1/torch/init.lua:87>
    [C]: in function 'DataSet'
    train.lua:31: in main chunk
    [C]: in function 'dofile'
    ...code/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:145: in main chunk
    [C]: at 0x0101673330
```
